### PR TITLE
remove interface argument to Dev.read() call

### DIFF
--- a/pyCCSniffer.py
+++ b/pyCCSniffer.py
@@ -329,7 +329,7 @@ class CC2531EMK:
 
         # While the running flag is set, continue to read from the USB device
         while self.running:
-            bytesteam = self.dev.read(CC2531EMK.DATA_EP, 4096, 0, CC2531EMK.DATA_TIMEOUT)
+            bytesteam = self.dev.read(CC2531EMK.DATA_EP, 4096, timeout=CC2531EMK.DATA_TIMEOUT)
 #             print "RECV>> %s" % binascii.hexlify(bytesteam)
 
             if len(bytesteam) >= 3:


### PR DESCRIPTION
This fixes https://github.com/andrewdodd/pyCCSniffer/issues/1.

The `interface` argument was removed at some point and is apparently unneeded.

I also specified the `timeout` argument by name, so this will still work with older versions of pyusb that still have the `interface` parameter.

I tested this against the latest pyusb on Linux, and the version of pyusb I had installed on windows, which still has the `read(self, endpoint, size, interface=None, timeout=None)` signature.
